### PR TITLE
Ensure the layout of `SoftAsciiStr` is same as `str`

### DIFF
--- a/src/soft_str.rs
+++ b/src/soft_str.rs
@@ -44,6 +44,11 @@ use soft_string::SoftAsciiString;
 /// Once it gets stabilized (rust #27721/#35729) implementations
 /// can be added
 #[derive(Debug,  PartialEq, Eq, PartialOrd, Ord, Hash)]
+// `repr(transparent)` ensures that the internal layout of
+// `SoftAsciiStr` is same as that of `str`.
+// Without this, `from_unchecked` and `from_unchecked_mut`
+// are unsound.
+#[repr(transparent)]
 pub struct SoftAsciiStr(str);
 
 


### PR DESCRIPTION
Without `#[repr(transparent)]`, the there are no guarantee of internal layouts being same, and `from_unchecked{,_mut}` will have undefied behavior.
The attribute is necessary for pointer casts (such as `&*(s as *const str as *const SoftAsciiStr)`) to be sound.